### PR TITLE
Validate email format via regex. Display error message if needed.

### DIFF
--- a/priv/static/app/app.js
+++ b/priv/static/app/app.js
@@ -4,6 +4,7 @@ fbConfigurator.controller('ConfiguratorController', function ConfiguratorControl
   $scope.ssids = [];
   $scope.should_use_ethernet = false;
   $scope.should_use_wifi = false;
+  $scope.showErrors = false;
   $http.get($scope.url + "/scan").then(function(resp){
     console.log(resp.data);
     $scope.ssids = resp.data;
@@ -54,7 +55,8 @@ fbConfigurator.controller('ConfiguratorController', function ConfiguratorControl
       }
     }
 
-    if(email != ""){
+    var EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    if(EMAIL_REGEX.test(email)){
       console.log(JSON.stringify(json));
       $http.post($scope.url + "/login", json).then(function(resp){
         console.log("Should never see this...");
@@ -62,6 +64,8 @@ fbConfigurator.controller('ConfiguratorController', function ConfiguratorControl
         console.log("will probably see this a lot...");
         console.log(JSON.stringify(error));
       });
+    } else {
+      $scope.showErrors = true;
     }
   };
 })

--- a/priv/static/configurator-styles.css
+++ b/priv/static/configurator-styles.css
@@ -100,3 +100,7 @@ li a {
   padding: 15px;
   border-radius: 4px;
 }
+
+.error {
+  color: red;
+}

--- a/priv/static/index.html
+++ b/priv/static/index.html
@@ -591,7 +591,14 @@
           </div>
           <!-- /farmbot  config-->
 
-          <a href="#" ng-click="submit()" class="btn btn-lg form-control save-button"> <strong>Save Configuration</strong> </a>
+          <div>
+            <div class='errors' ng-if='showErrors'>
+              <p class='error'>Invalid Email Address</p>
+            </div>
+            <div>
+              <a href="#" ng-click="submit()" class="btn btn-lg form-control save-button"> <strong>Save Configuration</strong> </a>
+            </div>
+          </div>
       </div>
 
     </div> <!-- /container -->


### PR DESCRIPTION
I've added a regex found on [stack overflow](http://stackoverflow.com/questions/46155/validate-email-address-in-javascript) to validate the email format and display a small error message if needed.

It's a slight tweak that will make initial configuration slightly smoother. 

To test
1. Run FarmbotConfigurator
2. Enter invalid email address and click 'Save Configuration' button

Expected Results

* Should see red `Invalid Email Address` message